### PR TITLE
fix(payment): Fixed error of losing voucher when user clicks browser Back button from VNPAY

### DIFF
--- a/backend/src/main/java/com/starview/cinemabooking/config/DataSeeder.java
+++ b/backend/src/main/java/com/starview/cinemabooking/config/DataSeeder.java
@@ -43,13 +43,15 @@ public class DataSeeder {
             // --- RESET DỮ LIỆU TOÀN BỘ (Theo yêu cầu) ---
             // Lưu ý: Phải xóa theo thứ tự từ bảng con đến bảng cha để tránh lỗi khóa ngoại
             System.out.println("🔄 Đang thực hiện reset toàn bộ dữ liệu...");
-            gheSuatChieuRepository.deleteAll();
-            donHangRepository.deleteAll();      // <-- 2. THÊM DÒNG NÀY ĐỂ XÓA ĐƠN HÀNG
-            suatChieuRepository.deleteAll();
-            phongChieuRepository.deleteAll();
-            phimRepository.deleteAll();
-            khuyenMaiRepository.deleteAll();
-            dichVuBanKemRepository.deleteAll();
+            
+            // THE FIX: Use InBatch to bypass Optimistic Locking checks
+            gheSuatChieuRepository.deleteAllInBatch();
+            donHangRepository.deleteAllInBatch();      // <-- 2. THÊM DÒNG NÀY ĐỂ XÓA ĐƠN HÀNG
+            suatChieuRepository.deleteAllInBatch();
+            phongChieuRepository.deleteAllInBatch();
+            phimRepository.deleteAllInBatch();
+            khuyenMaiRepository.deleteAllInBatch();
+            dichVuBanKemRepository.deleteAllInBatch();
 
             // --- TẠO TÀI KHOẢN STAFF MẪU ---
             // Chỉ tạo nếu chưa có tài khoản nào trong DB

--- a/backend/src/main/java/com/starview/cinemabooking/controller/TicketController.java
+++ b/backend/src/main/java/com/starview/cinemabooking/controller/TicketController.java
@@ -132,4 +132,25 @@ public class TicketController {
         String status = ticketService.getOrderStatus(orderId);
         return ResponseEntity.ok(Map.of("status", status));
     }
+    
+    @PostMapping("/cancel-abandoned")
+    public ResponseEntity<?> cancelAbandonedOrder(@RequestBody Map<String, String> payload) {
+        try {
+            String bookingRef = payload.get("bookingRef"); // Ví dụ: "DH5"
+            String sessionId = payload.get("sessionId"); // Frontend MUST send this now
+            
+            if (bookingRef != null && bookingRef.startsWith("DH")) {
+                Integer orderId = Integer.parseInt(bookingRef.substring(2));
+                
+                // Chỉ hủy nếu đơn hàng thực sự đang PENDING
+                if ("PENDING".equals(ticketService.getOrderStatus(orderId))) {
+                	ticketService.cancelAbandonedButKeepSeats(orderId, sessionId);
+                    return ResponseEntity.ok(Map.of("message", "Đã hủy đơn hàng bị bỏ rơi thành công."));
+                }
+            }
+            return ResponseEntity.ok(Map.of("message", "Đơn hàng không ở trạng thái PENDING."));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(Map.of("message", "Yêu cầu không hợp lệ."));
+        }
+    }
 }

--- a/backend/src/main/java/com/starview/cinemabooking/service/KhuyenMaiService.java
+++ b/backend/src/main/java/com/starview/cinemabooking/service/KhuyenMaiService.java
@@ -44,10 +44,10 @@ public class KhuyenMaiService {
         NguoiDung nguoiDung = getAuthenticatedUserOrThrow();
 
         // Mỗi tài khoản chỉ được dùng mỗi voucher một lần
-        validateSingleUsePerUser(nguoiDung, khuyenMai);
+        validateSingleUsePerUser(nguoiDung, khuyenMai, true);
 
         // Welcome voucher: chỉ dành cho tài khoản mua vé lần đầu (đơn SUCCESS đầu tiên)
-        validateWelcomeVoucherEligibility(nguoiDung, khuyenMai);
+        validateWelcomeVoucherEligibility(nguoiDung, khuyenMai, true);
 
         if (khuyenMai.getNgayHetHan() != null && khuyenMai.getNgayHetHan().isBefore(LocalDateTime.now())) {
             throw new IllegalStateException("Mã khuyến mãi đã hết hạn.");
@@ -61,13 +61,15 @@ public class KhuyenMaiService {
         float discountAmount = calculateDiscountAmount(khuyenMai, originalPrice);
         float discountedPrice = originalPrice - discountAmount;
 
-        khuyenMai.setDaSuDung(khuyenMai.getDaSuDung() == null ? 1 : khuyenMai.getDaSuDung() + 1);
-
-        try {
-            khuyenMaiRepository.save(khuyenMai);
-        } catch (OptimisticLockingFailureException e) {
-            throw new IllegalStateException("Mã khuyến mãi vừa hết lượt sử dụng. Vui lòng thử lại.");
-        }
+//        khuyenMai.setDaSuDung(khuyenMai.getDaSuDung() == null ? 1 : khuyenMai.getDaSuDung() + 1);
+//
+//        try {
+//            khuyenMaiRepository.save(khuyenMai);
+//        } catch (OptimisticLockingFailureException e) {
+//            throw new IllegalStateException("Mã khuyến mãi vừa hết lượt sử dụng. Vui lòng thử lại.");
+//        }
+        // Fix lỗi Eager Update, applyVoucher chỉ tính giảm giá, check mã voucher, check quyền dùng voucher của thành viên
+        // Chuyển update daSuDung counter sang webhook VNPay (TicketService.finalizeOrderSuccess)
 
         result.setDiscountAmount(discountAmount);
         result.setDiscountedPrice(discountedPrice);
@@ -90,8 +92,8 @@ public class KhuyenMaiService {
         NguoiDung nguoiDung = getAuthenticatedUserOrThrow();
 
         // Apply the same business rule in preview to avoid inconsistent UX
-        validateSingleUsePerUser(nguoiDung, khuyenMai);
-        validateWelcomeVoucherEligibility(nguoiDung, khuyenMai);
+        validateSingleUsePerUser(nguoiDung, khuyenMai, false);
+        validateWelcomeVoucherEligibility(nguoiDung, khuyenMai, false);
 
         if (khuyenMai.getNgayHetHan() != null && khuyenMai.getNgayHetHan().isBefore(LocalDateTime.now())) {
             throw new IllegalStateException("Mã khuyến mãi đã hết hạn.");
@@ -112,21 +114,25 @@ public class KhuyenMaiService {
         return result;
     }
 
-    private void validateWelcomeVoucherEligibility(NguoiDung nguoiDung, KhuyenMai khuyenMai) {
+    private void validateWelcomeVoucherEligibility(NguoiDung nguoiDung, KhuyenMai khuyenMai, boolean isCheckout) {
         if (khuyenMai == null || !khuyenMai.isDanhChoThanhVienMoi()) {
             return;
         }
-
-        // Block if they have ANY past successful orders, OR a pending order right now
-        List<String> blockingStatuses = Arrays.asList("SUCCESS", "PENDING");
+        
+        // Nếu là Preview, chỉ check SUCCESS. Nếu là Checkout, check cả PENDING để chặn Hack Multi-Tab.
+        List<String> blockingStatuses = isCheckout 
+                ? Arrays.asList("SUCCESS", "PENDING") 
+                : Arrays.asList("SUCCESS");
         long successfulOrderCount = donHangRepository.countByNguoiDungAndTrangThaiThanhToanIn(nguoiDung, blockingStatuses);
         if (successfulOrderCount > 0) {
             throw new IllegalStateException("Mã giảm giá này chỉ dành cho tài khoản mua vé lần đầu.");
         }
     }
 
-    private void validateSingleUsePerUser(NguoiDung nguoiDung, KhuyenMai khuyenMai) {
-    	List<String> blockingStatuses = Arrays.asList("SUCCESS", "PENDING");
+    private void validateSingleUsePerUser(NguoiDung nguoiDung, KhuyenMai khuyenMai, boolean isCheckout) {
+    	List<String> blockingStatuses = isCheckout 
+                ? Arrays.asList("SUCCESS", "PENDING") 
+                : Arrays.asList("SUCCESS");
     	long usedCount = donHangRepository.countByNguoiDungAndKhuyenMaiAndTrangThaiThanhToanIn(nguoiDung, khuyenMai,
                 blockingStatuses);
         if (usedCount > 0) {

--- a/backend/src/main/java/com/starview/cinemabooking/service/TicketService.java
+++ b/backend/src/main/java/com/starview/cinemabooking/service/TicketService.java
@@ -20,11 +20,13 @@ import com.starview.cinemabooking.dtos.EmailTicketRequest;
 import com.starview.cinemabooking.dtos.VoucherApplyResult;
 import com.starview.cinemabooking.model.DonHang;
 import com.starview.cinemabooking.model.GheSuatChieu;
+import com.starview.cinemabooking.model.KhuyenMai;
 import com.starview.cinemabooking.model.NguoiDung;
 import com.starview.cinemabooking.model.Phim;
 import com.starview.cinemabooking.model.SuatChieu;
 import com.starview.cinemabooking.repository.DonHangRepository;
 import com.starview.cinemabooking.repository.GheSuatChieuRepository;
+import com.starview.cinemabooking.repository.KhuyenMaiRepository;
 import com.starview.cinemabooking.repository.NguoiDungRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,7 @@ public class TicketService {
     private final GheSuatChieuRepository gheSuatChieuRepository;
     private final DonHangRepository donHangRepository;
     private final NguoiDungRepository nguoiDungRepository;
+    private final KhuyenMaiRepository khuyenMaiRepository;
     private final EmailService emailService;
     private final KhuyenMaiService khuyenMaiService;
 
@@ -252,6 +255,21 @@ public class TicketService {
             totalPrice += ghe.calculatePrice();
         }
         
+        // --- THE FIX: XỬ LÝ QUAY VỀ TỪ VNPAY ---
+        // Nếu các ghế này đang dính với một đơn hàng PENDING cũ của chính user này, 
+        // ta sẽ đánh dấu đơn cũ là FAILED để "nhả" voucher ra ngay lập tức.
+        DonHang oldOrder = seats.get(0).getDonHang();
+        if (oldOrder != null && "PENDING".equals(oldOrder.getTrangThaiThanhToan())) {
+            oldOrder.setTrangThaiThanhToan("FAILED");
+            donHangRepository.save(oldOrder);
+            
+            // Lệnh flush() CỰC KỲ QUAN TRỌNG: Ép Hibernate cập nhật Database ngay lập tức 
+            // thay vì đợi đến cuối transaction, để hàm applyVoucher bên dưới thấy voucher đã được nhả.
+            donHangRepository.flush(); 
+            log.info("Canceled old PENDING order {} because user re-initiated checkout.", oldOrder.getId());
+        }
+        // ------------------------------------------
+        
         // 2. THE FIX: Áp dụng voucher ở đây!
         VoucherApplyResult voucherResult = khuyenMaiService.applyVoucher(request.getVoucherCode(), totalPrice);
 
@@ -300,6 +318,15 @@ public class TicketService {
 
         // 1. Mark Order as Paid
         donHang.setTrangThaiThanhToan("SUCCESS");
+        
+        // --- NEW FIX: Update lượt sử dụng voucher khi đã thanh toán thành công ---
+        if (donHang.getKhuyenMai() != null) {
+            KhuyenMai km = donHang.getKhuyenMai();
+            km.setDaSuDung(km.getDaSuDung() == null ? 1 : km.getDaSuDung() + 1);
+            // Lưu lại số lượng voucher đã xài
+            khuyenMaiRepository.save(km); 
+        }
+        // ---------------------------------------------------------
         
         if (donHang.getNguoiDung() != null) {
         	NguoiDung user = donHang.getNguoiDung();
@@ -376,6 +403,29 @@ public class TicketService {
         }
         gheSuatChieuRepository.saveAll(seats);
         log.warn("Order {} failed/canceled. Seats released.", orderId);
+    }
+	
+	@Transactional
+    public void cancelAbandonedButKeepSeats(Integer orderId, String sessionId) {
+        DonHang donHang = donHangRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("Không tìm thấy đơn hàng"));
+
+        // 1. Fail the order to release the voucher and points
+        donHang.setTrangThaiThanhToan("FAILED");
+        donHangRepository.save(donHang);
+
+        // 2. Unlink the seats from the failed order, BUT keep them locked for this user!
+        List<GheSuatChieu> seats = gheSuatChieuRepository.findByDonHang(donHang);
+        for (GheSuatChieu ghe : seats) {
+            ghe.setDonHang(null); // Unlink so the voucher isn't tied to these seats anymore
+            
+            // TÁI GIA HẠN GIỮ CHỖ (Reset 5-minute timer)
+            ghe.setTrangThai("DANG_CHO");
+            ghe.setPhienGiaoDich(sessionId); 
+            ghe.setThoiGianHetHanGiuCho(LocalDateTime.now().plusMinutes(5));
+        }
+        gheSuatChieuRepository.saveAll(seats);
+        log.info("Order {} failed/abandoned. Seats kept locked for session {}.", orderId, sessionId);
     }
 
     @Transactional(readOnly = true)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2879,9 +2879,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/components/Login/Login.jsx
+++ b/frontend/src/components/Login/Login.jsx
@@ -72,7 +72,7 @@ function Login() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required 
-            placeholder="Nhập email của staff..."
+            placeholder="Nhập email của thành viên..."
           />
         </div>
 

--- a/frontend/src/components/Payment/Payment.jsx
+++ b/frontend/src/components/Payment/Payment.jsx
@@ -54,6 +54,15 @@ function Payment() {
 
   const isLoggedIn = !!sessionStorage.getItem('token');
 
+  // THE FIX: Chuyên phục hồi Voucher từ Session Storage khi trang được load lại
+  useEffect(() => {
+    const savedCode = sessionStorage.getItem('STARVIEW_VOUCHER');
+    if (savedCode) {
+      // Gọi API để Backend tính lại giá mới nhất thay vì dùng giá chết
+      handleApplyVoucher(savedCode);
+    }
+  }, [totalPrice]); // <-- Quan trọng: Lắng nghe sự thay đổi của totalPrice
+
   // Tự động điền email nếu người dùng đã đăng nhập
   useEffect(() => {
     const token = sessionStorage.getItem('token');
@@ -138,6 +147,7 @@ function Payment() {
             // Xóa giỏ hàng và đếm ngược
             sessionStorage.removeItem('STARVIEW_CART');
             sessionStorage.removeItem('STARVIEW_COUNTDOWN');
+            sessionStorage.removeItem('STARVIEW_VOUCHER'); // <-- Thêm xóa voucher
 
             // Phục hồi lại data vé từ sessionStorage (do khi redirect sang VNPay React bị mất state)
             const savedTicketData = sessionStorage.getItem('TEMP_TICKET_DATA');
@@ -175,6 +185,7 @@ function Payment() {
       // Xóa các ghế đã chọn và countdown khỏi sessionStorage khi hết giờ
       sessionStorage.removeItem('STARVIEW_CART');
       sessionStorage.removeItem('STARVIEW_COUNTDOWN');
+      sessionStorage.removeItem('STARVIEW_VOUCHER'); // <-- Thêm dòng này để xóa voucher trong session
 
       // Ép backend nhả toàn bộ ghế dựa vào danh sách ID ghế đã lưu ở bước trước
       if (selectedSeatIds && selectedSeatIds.length > 0 && sessionId) {
@@ -219,6 +230,7 @@ function Payment() {
             alert("Thời gian giữ ghế đã hết. Vui lòng chọn lại ghế.");
             sessionStorage.removeItem('STARVIEW_CART');
             sessionStorage.removeItem('STARVIEW_COUNTDOWN');
+            sessionStorage.removeItem('STARVIEW_VOUCHER');
             navigate(`/phim/${movie.id}/seatselection?cinema=${cinemaName}&time=${showtime}&date=${showdate}&suatChieuId=${suatChieuId}`);
             return 0;
           }
@@ -234,6 +246,44 @@ function Payment() {
       }
     };
   }, [paymentCountdown, navigate, movie, cinemaName, showtime, showdate, suatChieuId, selectedSeatIds, sessionId, isVerifyingVNPay]);
+
+  // THE FIX: Phát hiện ấn nút "Back" và giữ nguyên trạng thái UI (Seamless Retry)
+  useEffect(() => {
+    const savedTicketDataStr = sessionStorage.getItem('TEMP_TICKET_DATA');
+    
+    if (savedTicketDataStr && !isVerifyingVNPay) {
+      try {
+        const savedData = JSON.parse(savedTicketDataStr);
+        if (savedData.bookingRef) {
+          
+          fetch(`${baseUrl}/api/v1/bookings/cancel-abandoned`, {
+            method: 'POST',
+            headers: getAuthHeaders(),
+            body: JSON.stringify({ 
+              bookingRef: savedData.bookingRef,
+              sessionId: sessionId // Lấy sessionId từ location.state để backend gia hạn ghế
+            })
+          })
+          .then(() => {
+            console.log("Đã hủy đơn PENDING nhưng giữ lại ghế trên UI.");
+            
+            // Xóa rác chuyển hướng VNPay, nhưng GIỮ LẠI STARVIEW_CART và STARVIEW_VOUCHER
+            sessionStorage.removeItem('TEMP_TICKET_DATA');
+            
+            // Khôi phục lại bộ đếm đếm ngược (reset lại 5 phút = 300 giây)
+            setPaymentCountdown(300); 
+            
+            // Báo lỗi nhẹ nhàng ngay dưới nút thanh toán thay vì che toàn bộ màn hình
+            setVoucherError("Giao dịch VNPay đã bị hủy. Bạn có thể thanh toán lại.");
+            setIsProcessing(false);
+          })
+          .catch(err => console.error("Lỗi khi hủy đơn abandoned:", err));
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  }, [isVerifyingVNPay, baseUrl, sessionId]);
 
   // 1. ƯU TIÊN SỐ 1: NẾU ĐÃ THANH TOÁN THÀNH CÔNG -> HIỂN THỊ POPUP VÉ
   // (Đặt trên cùng để bypass mọi màn hình loading và tránh crash do mất state)
@@ -287,8 +337,8 @@ function Payment() {
     );
   }
 
-  const handleApplyVoucher = async () => {
-    if (!voucherCode.trim()) return;
+  const handleApplyVoucher = async (codeToApply = voucherCode) => {
+    if (!codeToApply.trim()) return;
     setVoucherError(''); // Reset lỗi trước khi gọi API
 
     try {
@@ -296,7 +346,7 @@ function Payment() {
         method: 'POST',
         headers: getAuthHeaders(),
         body: JSON.stringify({
-          voucherCode: voucherCode,
+          voucherCode: codeToApply,
           originalPrice: totalPrice // Gửi giá gốc để backend tính toán
         })
       });
@@ -312,11 +362,31 @@ function Payment() {
       setFinalPrice(result.discountedPrice);
       setDiscountAmount(result.discountAmount);
       setIsVoucherApplied(true);
+      setVoucherCode(codeToApply);
+
+      // THE FIX: Lưu vào sessionStorage để phục hồi nếu khách bấm Back từ VNPay
+      // THE FIX: CHỈ LƯU MÃ CODE, KHÔNG LƯU TÍNH TOÁN!
+      sessionStorage.setItem('STARVIEW_VOUCHER', codeToApply);
 
     } catch (error) {
       // Hiển thị lỗi ngay dưới ô nhập voucher
       setVoucherError(error.message);
+      // Nếu API báo lỗi (vd: user vừa dùng ở tab khác), tự dọn dẹp cache
+      sessionStorage.removeItem('STARVIEW_VOUCHER');
+      setIsVoucherApplied(false);
+      setFinalPrice(totalPrice);
+      setDiscountAmount(0);
     }
+  };
+
+  // 3. Hàm gỡ voucher
+  const handleRemoveVoucher = () => {
+    setIsVoucherApplied(false);
+    setVoucherCode('');
+    setFinalPrice(totalPrice); // Trả về giá gốc
+    setDiscountAmount(0);
+    setVoucherError('');
+    sessionStorage.removeItem('STARVIEW_VOUCHER'); // Xóa khỏi cache
   };
 
   const handlePayment = async (e) => {
@@ -488,9 +558,15 @@ function Payment() {
               value={voucherCode} onChange={(e) => setVoucherCode(e.target.value.toUpperCase())}
               disabled={isVoucherApplied}
             />
-            <button type="button" onClick={handleApplyVoucher} disabled={isVoucherApplied || !voucherCode.trim()}>
-              {isVoucherApplied ? 'Đã áp dụng' : 'Áp dụng'}
-            </button>
+            {isVoucherApplied ? (
+              <button type="button" onClick={handleRemoveVoucher} style={{ backgroundColor: '#dc3545' }}>
+                Hủy bỏ
+              </button>
+            ) : (
+              <button type="button" onClick={() => handleApplyVoucher(voucherCode)} disabled={!voucherCode.trim()}>
+                Áp dụng
+              </button>
+            )}
           </div>
           {/* Hiển thị lỗi voucher nếu có */}
           {voucherError && <p className="voucher-error-text">{voucherError}</p>}


### PR DESCRIPTION
- Ticket Controller & Service: Added /bookings/cancel-abandoned endpoint for changing order status to FAILED when user clicks browser Back button from VNPay, unlinking seats from failed order without unlocking so user session keeps selected seats and applied vouchers

- TicketService: Added DB flush safety net in creatPendingOrder to auto cancel any hanging PENDING orders on the same seats when creating a new order to prevent deadlocks

- KhuyenMaiService: Removed eager update of daSuDung, moved to TicketService.finalizeOrderSuccess

- KhuyenMaiService: Added isCheckout bool flag to validation rules, previewVoucher now ignores PENDING orders, only checking welcome voucher eligibility and single-use-per-user rules in applyVoucher

- Payment.jsx: Implemented useEffect retreat detector using /cancel-abandoned endpoint and voucherCode saved in sessionStorage to restore user voucher, session only stores voucherCode forcing price recalculation if total changes